### PR TITLE
Optimize publication path when messages are expiring

### DIFF
--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -44,6 +44,7 @@ dep_rabbitmq_event_exchange           = git_rmq rabbitmq-event-exchange $(curren
 dep_rabbitmq_federation               = git_rmq rabbitmq-federation $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_federation_management    = git_rmq rabbitmq-federation-management $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_java_client              = git_rmq rabbitmq-java-client $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_jms_topic_exchange       = git_rmq rabbitmq-jms-topic-exchange $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_lvc                      = git_rmq rabbitmq-lvc-plugin $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_management               = git_rmq rabbitmq-management $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_management_agent         = git_rmq rabbitmq-management-agent $(current_rmq_ref) $(base_rmq_ref) master
@@ -62,6 +63,7 @@ dep_rabbitmq_stomp                    = git_rmq rabbitmq-stomp $(current_rmq_ref
 dep_rabbitmq_toke                     = git_rmq rabbitmq-toke $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_top                      = git_rmq rabbitmq-top $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_tracing                  = git_rmq rabbitmq-tracing $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_trust_store              = git_rmq rabbitmq-trust-store $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_test                     = git_rmq rabbitmq-test $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_web_dispatch             = git_rmq rabbitmq-web-dispatch $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_web_stomp                = git_rmq rabbitmq-web-stomp $(current_rmq_ref) $(base_rmq_ref) master
@@ -99,6 +101,7 @@ RABBITMQ_COMPONENTS = amqp_client \
 		      rabbitmq_federation \
 		      rabbitmq_federation_management \
 		      rabbitmq_java_client \
+		      rabbitmq_jms_topic_exchange \
 		      rabbitmq_lvc \
 		      rabbitmq_management \
 		      rabbitmq_management_agent \
@@ -118,6 +121,7 @@ RABBITMQ_COMPONENTS = amqp_client \
 		      rabbitmq_toke \
 		      rabbitmq_top \
 		      rabbitmq_tracing \
+		      rabbitmq_trust_store \
 		      rabbitmq_web_dispatch \
 		      rabbitmq_web_mqtt \
 		      rabbitmq_web_mqtt_examples \


### PR DESCRIPTION
We saw some unusual CPU spikes when we migrated our direct exchanges to a delayed exchange in a heavy traffic environment.  The CPU spikes did not correlate well with the amount of traffic, making this behavior very suspicious.

After some investigation [1], we found that both publication to the exchange and message timeout expiry were quite fast.  However, when publication and message expiry were occurring at the same time, the publication rate plummeted and CPU usage skyrocketed.

The root cause of this issue appears to be the branch of code intended to start a timer when we publish the first delayed message to an empty exchange.  That code is triggered by accident when we publish new messages while the exchange is falling behind in its handling of expired messages.  That code path happens to be much slower than the regular case.

This PR avoids the issue by moving the responsibility for starting the initial timer from the publication code path to the exchange itself.  Now it maintains a timer in the distant future as a placeholder even when there are no delayed messages sitting in the queue.

[1] https://groups.google.com/forum/#!topic/rabbitmq-users/XgjY7UtLkfs