### PR TITLE
Track timer state to optimize message publication

### DIFF
--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -44,6 +44,7 @@ dep_rabbitmq_event_exchange           = git_rmq rabbitmq-event-exchange $(curren
 dep_rabbitmq_federation               = git_rmq rabbitmq-federation $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_federation_management    = git_rmq rabbitmq-federation-management $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_java_client              = git_rmq rabbitmq-java-client $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_jms_topic_exchange       = git_rmq rabbitmq-jms-topic-exchange $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_lvc                      = git_rmq rabbitmq-lvc-plugin $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_management               = git_rmq rabbitmq-management $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_management_agent         = git_rmq rabbitmq-management-agent $(current_rmq_ref) $(base_rmq_ref) master
@@ -62,6 +63,7 @@ dep_rabbitmq_stomp                    = git_rmq rabbitmq-stomp $(current_rmq_ref
 dep_rabbitmq_toke                     = git_rmq rabbitmq-toke $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_top                      = git_rmq rabbitmq-top $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_tracing                  = git_rmq rabbitmq-tracing $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_trust_store              = git_rmq rabbitmq-trust-store $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_test                     = git_rmq rabbitmq-test $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_web_dispatch             = git_rmq rabbitmq-web-dispatch $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_web_stomp                = git_rmq rabbitmq-web-stomp $(current_rmq_ref) $(base_rmq_ref) master
@@ -99,6 +101,7 @@ RABBITMQ_COMPONENTS = amqp_client \
 		      rabbitmq_federation \
 		      rabbitmq_federation_management \
 		      rabbitmq_java_client \
+		      rabbitmq_jms_topic_exchange \
 		      rabbitmq_lvc \
 		      rabbitmq_management \
 		      rabbitmq_management_agent \
@@ -118,6 +121,7 @@ RABBITMQ_COMPONENTS = amqp_client \
 		      rabbitmq_toke \
 		      rabbitmq_top \
 		      rabbitmq_tracing \
+		      rabbitmq_trust_store \
 		      rabbitmq_web_dispatch \
 		      rabbitmq_web_mqtt \
 		      rabbitmq_web_mqtt_examples \

--- a/src/rabbit_delayed_message.erl
+++ b/src/rabbit_delayed_message.erl
@@ -111,7 +111,7 @@ disable_plugin() ->
 %%--------------------------------------------------------------------
 
 init([]) ->
-    {ok, #state{timer = make_ref()}}.
+    {ok, #state{timer = not_set}}.
 
 handle_call({delay_message, Exchange, Delivery, Delay},
             _From, State = #state{timer = CurrTimer}) ->
@@ -127,14 +127,12 @@ handle_call({delay_message, Exchange, Delivery, Delay},
 handle_call(_Req, _From, State) ->
     {reply, unknown_request, State}.
 
-handle_cast(go, State = #state{timer = CurrTimer}) ->
-    maybe_delay_first(CurrTimer),
-    {noreply, State};
+handle_cast(go, State) ->
+    {noreply, State#state{timer = maybe_delay_first()}};
 handle_cast(_C, State) ->
     {noreply, State}.
 
-handle_info({timeout, _TimerRef, {deliver, Key}},
-            State = #state{timer = CurrTimer}) ->
+handle_info({timeout, _TimerRef, {deliver, Key}}, State) ->
     case mnesia:dirty_read(?TABLE_NAME, Key) of
         [] ->
             ok;
@@ -143,8 +141,7 @@ handle_info({timeout, _TimerRef, {deliver, Key}},
             mnesia:dirty_delete(?TABLE_NAME, Key),
             mnesia:dirty_delete(?INDEX_TABLE_NAME, Key)
     end,
-
-    {noreply, State#state{timer = maybe_delay_first(CurrTimer)}};
+    {noreply, State#state{timer = maybe_delay_first()}};
 handle_info(_I, State) ->
     {noreply, State}.
 
@@ -155,7 +152,7 @@ code_change(_, State, _) -> {ok, State}.
 
 %%--------------------------------------------------------------------
 
-maybe_delay_first(CurrTimer) ->
+maybe_delay_first() ->
     case mnesia:dirty_first(?INDEX_TABLE_NAME) of
         %% destructuring to prevent matching '$end_of_table'
         #delay_key{timestamp = FirstTS} = Key2 ->
@@ -164,7 +161,7 @@ maybe_delay_first(CurrTimer) ->
             start_timer(FirstTS - Now, Key2);
         _ ->
             %% nothing to do
-            CurrTimer
+            not_set
     end.
 
 route(#delay_key{exchange = Ex}, Deliveries) ->
@@ -183,26 +180,24 @@ internal_delay_message(CurrTimer, Exchange, Delivery, Delay) ->
                        make_index(DelayTS, Exchange)),
     mnesia:dirty_write(?TABLE_NAME,
                        make_delay(DelayTS, Exchange, Delivery)),
-    case erlang:read_timer(CurrTimer) of
-        false ->
-            %% last timer expired, we set a new timer for
-            %% the next message to be delivered
-            case mnesia:dirty_first(?INDEX_TABLE_NAME) of
-                %% destructuring to prevent matching '$end_of_table'
-                #delay_key{timestamp = FirstTS} = Key
-                  when FirstTS < DelayTS ->
-                    %% there are messages that expired and need to be delivered
-                    {ok, start_timer(FirstTS - Now, Key)};
+    case CurrTimer of
+        not_set ->
+            %% No timer in progress, so we start our own.
+            {ok, maybe_delay_first()};
+        _ ->
+            case erlang:read_timer(CurrTimer) of
+                false ->
+                    %% Timer is already expired.  Handler will be invoked soon.
+                    {ok, CurrTimer};
+                CurrMS when Delay < CurrMS ->
+                    %% Current timer lasts longer that new message delay
+                    erlang:cancel_timer(CurrTimer),
+                    {ok, start_timer(Delay, make_key(DelayTS, Exchange))};
                 _ ->
-                    %% empty table or DelayTS <= FirstTS
-                    {ok, start_timer(Delay, make_key(DelayTS, Exchange))}
-            end;
-        CurrMS when Delay < CurrMS ->
-            %% Current timer lasts longer that new message delay
-            erlang:cancel_timer(CurrTimer),
-            {ok, start_timer(Delay, make_key(DelayTS, Exchange))};
-        _  ->
-            {ok, CurrTimer}
+                    %% Timer is set to expire sooner than this
+                    %% message's scheduled delivery time.
+                    {ok, CurrTimer}
+            end
     end.
 
 %% Key will be used upon message receipt to fetch


### PR DESCRIPTION
Tracks the state of the timer so we can tell the difference between the timer being expired and the timer not being set.  This allows us to avoid settings lots of redundant timers when publishing messages while other messages are reaching their delivery time.  

See https://groups.google.com/forum/#!topic/rabbitmq-users/XgjY7UtLkfs and https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/pull/51 for more information.