### PR TITLE
Set bounded timeout for OTP workers

### DIFF
--- a/src/rabbit_delayed_message_sup.erl
+++ b/src/rabbit_delayed_message_sup.erl
@@ -39,7 +39,7 @@ start_link() ->
 init([]) ->
     {ok, {{one_for_one, 3, 10},
           [{rabbit_delayed_message, {rabbit_delayed_message, start_link, []},
-            transient, ?MAX_WAIT, worker, [rabbit_delayed_message]}]}}.
+            transient, ?WORKER_WAIT, worker, [rabbit_delayed_message]}]}}.
 
 stop() ->
     ok = supervisor:terminate_child(rabbit_sup, ?MODULE),


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT` 