### PR TITLE
Explicitly recover binding on plugin init

### DIFF
--- a/src/rabbit_delayed_message.erl
+++ b/src/rabbit_delayed_message.erl
@@ -224,14 +224,14 @@ recover() ->
     %% starting with RabbitMQ 3.8.4
     case list_exchanges() of
         {ok, Xs} ->
-            rabbit_log:debug("Delayed message exchange:
-                              have ~b durable exchanges to recover",
+            rabbit_log:debug("Delayed message exchange: "
+                              "have ~b durable exchanges to recover",
                              [length(Xs)]),
             [recover_exchange_and_bindings(X) || X <- lists:usort(Xs)];
         {aborted, Reason} ->
             rabbit_log:error(
-                "Delayed message exchange:
-                 failed to recover durable exchange ring state, reason: ~p",
+                "Delayed message exchange: "
+                 "failed to recover durable bindings of one of the exchanges, reason: ~p",
                 [Reason])
     end.
 
@@ -255,7 +255,7 @@ recover_exchange_and_bindings(#exchange{name = XName} = X) ->
             Bindings = rabbit_binding:list_for_source(XName),
             [rabbit_exchange_type_delayed_message:add_binding(transaction, X, B)
              || B <- lists:usort(Bindings)],
-            rabbit_log:debug("Delayed message exchange:
-                              recovered bindings for exchange ~s",
+            rabbit_log:debug("Delayed message exchange: "
+                              "recovered bindings for ~s",
                              [rabbit_misc:rs(XName)])
     end).


### PR DESCRIPTION
As the boot step "enables" configuration isn't honored during server boot.


I think this Fixes #149 but a thorough review is required.