### PR TITLE
Increase hardcoded timeout to 15 minutes

### DIFF
--- a/src/rabbit_delayed_message.erl
+++ b/src/rabbit_delayed_message.erl
@@ -90,7 +90,7 @@ setup_mnesia() ->
                                              record_info(fields, delay_index)},
                                             {type, ordered_set},
                                             {disc_copies, [node()]}]),
-    mnesia:wait_for_tables([?TABLE_NAME, ?INDEX_TABLE_NAME], 30000).
+    mnesia:wait_for_tables([?TABLE_NAME, ?INDEX_TABLE_NAME], 900000).
 
 disable_plugin() ->
     mnesia:delete_table(?INDEX_TABLE_NAME),


### PR DESCRIPTION
The 30 second timeout is too short for our environment.  Ideally, this would be configurable, but it would be nice to at least have a longer, fixed timeout.

## Proposed Changes

Increase the hardcoded timeout value.  Since this value is not currently user-configurable, this provides a workaround for users who experience crashes on startup loading the mnesia table.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
Is this considered a 'trivial' change, that does not require the CA?

- [ ] All tests pass locally with my changes
Tests are all skipped in my local environment:
```
plugin_SUITE
    {skip,"Failed to create SSL certificates"}
```

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
No dependent changes

## Further Comments

None at this time.
