### PR TITLE
Use the rabbit_table facility to defer timeout to configuration value

### DIFF
--- a/src/rabbit_delayed_message.erl
+++ b/src/rabbit_delayed_message.erl
@@ -90,7 +90,7 @@ setup_mnesia() ->
                                              record_info(fields, delay_index)},
                                             {type, ordered_set},
                                             {disc_copies, [node()]}]),
-    mnesia:wait_for_tables([?TABLE_NAME, ?INDEX_TABLE_NAME], 30000).
+    rabbit_table:wait([?TABLE_NAME, ?INDEX_TABLE_NAME]).
 
 disable_plugin() ->
     mnesia:delete_table(?INDEX_TABLE_NAME),


### PR DESCRIPTION
## Proposed Changes

Apply the approach from https://github.com/rabbitmq/rabbitmq-server/pull/3067 to this plugin as well.  This allows users to configure the timeout for this plugin to boot via the existing configuration setting.

Replaces https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/pull/162

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
This change is textually identical to the PR linked above.  Does that constitute trivial for the purposes of the CA?

- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
Depends on RabbitMQ core 3.6.x, which is already below the required version of 3.7.0 in this plugin.

## Further Comments

No further comments at this time.
