### PR TITLE
Updated readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ delivered to the respective queues after `x-delay` milliseconds.
 
 ## Supported RabbitMQ Versions
 
-The most recent release of this plugin targets RabbitMQ 3.8.x.
-Earlier series are [out of support](https://www.rabbitmq.com/versions.html).
+The most recent release of this plugin targets RabbitMQ 3.9.x.
+Series earlier than 3.8.x are [out of support](https://www.rabbitmq.com/versions.html).
 
 ## Supported Erlang/OTP Versions
 
@@ -19,10 +19,10 @@ This plugin [requires Erlang 23.2 or later versions](https://www.rabbitmq.com/wh
 
 ## Project Maturity
 
-This plugin is considered to be **experimental yet fairly stable and potential suitable for production use
+This plugin is considered to be **fairly stable and potential suitable for production use
 as long as the user is aware of its limitations**.
 
-It had a few issues and one fundamental problem fixed in its ~ 18 months of
+It had a few issues and one fundamental problem fixed in its ~ 5 years of
 existence. It is known to work reasonably well for some users.
 It also has **known limitations** (see a section below),
 including those related to the replication of delayed and messages and the number of delayed messages.


### PR DESCRIPTION
Matching RabbitMQ 3.9.x series

## Proposed Changes

The readme file as not been updated for latest 3.9.x release (minor issue). It states that the latest support series is 3.8.x, which is not correct.
The project Maturity section could do with an update. Especially, the sentence ”few issues and one fundamental problem fixed in its ~ 18 months of existence”. I believe that the plugin has existed in ~ 5 years.

Why:
These is a minor issues, but the challenge is that some operation teams read this readme file as kind of a release note – and they raise concern about the maturity of the plugin and use in a production environment.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
