### PR TITLE
Only consider exchange name when looking up number of delayed messages

### DIFF
--- a/src/rabbit_delayed_message.erl
+++ b/src/rabbit_delayed_message.erl
@@ -98,7 +98,8 @@ disable_plugin() ->
     ok.
 
 messages_delayed(Exchange) ->
-    MatchHead = #delay_entry{delay_key = make_key('_', Exchange),
+    ExchangeName = Exchange#exchange.name,
+    MatchHead = #delay_entry{delay_key = make_key('_', #exchange{name = ExchangeName, _ = '_'}),
                              delivery  = '_', ref       = '_'},
     Delays = mnesia:dirty_select(?TABLE_NAME, [{MatchHead, [], ['$_']}]),
     length(Delays).


### PR DESCRIPTION
## Proposed Changes

The `#exchange` record contains fields like policy or options which can
change for an exchange after delayed messages have been stored,
resulting in no match and an apparent zero number of messages
displayed on the Management UI.

Alternatively it would be possible to only store the exchange `name` field in the key, but that would require some upgrade code (which I would need some guidance with). When a delayed message is delivered only the `name` and `decorators` fields are used by `rabbit_exchange:route/2`. (This highlights that currently if decorators change, this won't be reflected for messages already delayed.)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
