### PR TITLE
Conversion to float numbers implemented in try_convert_to_int

### DIFF
--- a/src/rabbit_delayed_message_utils.erl
+++ b/src/rabbit_delayed_message_utils.erl
@@ -16,6 +16,8 @@
 
 -define(STRING_ARG_TYPES, [longstr, shortstr]).
 
+-define(FLOAT_ARG_TYPES, [decimal, double, float]).
+
 -import(rabbit_misc, [table_lookup/2, set_table_value/4]).
 
 get_delay(Delivery) ->
@@ -91,7 +93,11 @@ get_headers(#'P_basic'{headers = H}) ->
 try_convert_to_int(Type, Delay) ->
     case lists:member(Type, ?STRING_ARG_TYPES) of
         true  -> {ok, binary_to_integer(Delay)};
-        false -> {error, {unacceptable_type, Type}}
+        false -> 
+            case lists:member(Type, ?FLOAT_ARG_TYPES) of
+                true  -> {ok, trunc(Delay)};
+                false -> {error, {unacceptable_type, Type}}
+            end.
     end.
 
 %% adapted from rabbit_amqqueue.erl


### PR DESCRIPTION
## Proposed Changes

Conversion to float numbers added in try_convert_to_int.

try_convert_to_int function tries to convert value passed with header "x-delay" into int. But currently it only supports string to int conversion. Certain languages (for example .NET) have common API for time utilities (TimeSpan.TotalMilliseconds) which return double type value. If it is not casted into integer type before passing it to header as a value - it is being ignored in the try_convert_to_int and there is no way (except for looking into plugin source code) why it didn't work.

Note regarding tests. I wasn't able to pass all tests with or without my changes. If someone would assist with help how to run them properly - would be able to add tests for my changes.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
