### PR TITLE
Continue to use direct exchange routing v1

### DIFF
--- a/test/plugin_SUITE.erl
+++ b/test/plugin_SUITE.erl
@@ -150,8 +150,6 @@ e2e_nodelay(Config) ->
     e2e_test0(Config, [0]).
 
 e2e_delay(Config) ->
-    %% message delay will be 0,
-    %% we are testing e2e without delays
     e2e_test0(Config, [500, 100, 300, 200, 100, 400]).
 
 e2e_test0(Config, Msgs) ->


### PR DESCRIPTION
x-delayed-message exchange type does not use direct exchange routing v2
even when this feature flag is enabled.
Therefore, route directly via rabbit_router:match_routing_key/2 which corresponds
to "direct exchange routing v1".

Fixes failing tests against rabbitmq-server master branch.

Similar to what's done in https://github.com/rabbitmq/rabbitmq-lvc-exchange/pull/32.

Fixes #199 

