### PR TITLE
Don't get stuck on index key with no messages

### DIFF
--- a/src/rabbit_delayed_message.erl
+++ b/src/rabbit_delayed_message.erl
@@ -29,7 +29,9 @@
 -export([messages_delayed/1]).
 
 %% For testing, debugging and manual use
--export([refresh_config/0]).
+-export([refresh_config/0,
+         table_name/0,
+         index_table_name/0]).
 
 -import(rabbit_delayed_message_utils, [swap_delay_header/1]).
 
@@ -141,7 +143,7 @@ handle_cast(_C, State) ->
 handle_info({timeout, _TimerRef, {deliver, Key}}, State) ->
     case mnesia:dirty_read(?TABLE_NAME, Key) of
         [] ->
-            ok;
+            mnesia:dirty_delete(?INDEX_TABLE_NAME, Key);
         Deliveries ->
             route(Key, Deliveries, State),
             mnesia:dirty_delete(?TABLE_NAME, Key),
@@ -162,7 +164,7 @@ maybe_delay_first() ->
     case mnesia:dirty_first(?INDEX_TABLE_NAME) of
         %% destructuring to prevent matching '$end_of_table'
         #delay_key{timestamp = FirstTS} = Key2 ->
-            %% there are messages that expired and need to be delivered
+            %% there are messages that will expire and need to be delivered
             Now = erlang:system_time(milli_seconds),
             start_timer(FirstTS - Now, Key2);
         _ ->
@@ -314,3 +316,9 @@ bump_routed_stats(ExName, Qs, State) ->
 
 refresh_config(State) ->
     rabbit_event:init_stats_timer(State, #state.stats_state).
+
+table_name() ->
+    ?TABLE_NAME.
+
+index_table_name() ->
+    ?INDEX_TABLE_NAME.


### PR DESCRIPTION
## Proposed Changes

When the delayed_message gen_server encounters the next timestamp in the index table and there are no messages in the main table associated, it would loop forever, as this timestamp will stay the "first" key in the index table.

This commit makes sure the expired index entry gets deleted even if there are no associated messages.

This situation can happen if the node is abruptly stopped in the middle of delaying a messsage (after writing to the index table but before writing to the main table).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
