### PR TITLE
Use rabbitmq/bazel-central-registry@erlang-packages bzlmod registry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,7 @@
 build --enable_bzlmod
-# build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/dev/
+
+build --registry=https://bcr.bazel.build/
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/erlang-packages/
 
 build --incompatible_strict_action_env
 build --local_test_jobs=1


### PR DESCRIPTION
recent versions of osiris are available from this registry