### PR TITLE
Ensure Mnesia is running when Khepri is used as main metadata store

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ of some kind.
 
 The most recent release of this plugin targets RabbitMQ 4.0.x.
 
-This plugin currently only supports Mnesia for metadata store (do not use it with Khepri).
+This plugin can be enabled on a RabbitMQ cluster that uses either Mnesia or Khepri as metadata store.
+
+Warning: the plugin must be disabled during Khepri migration. One
+needs to disable this plugin before enabling the `khepri_db` feature
+flag and enable it after. This will result in losing all previous
+delayed messages.
 
 ## Supported Erlang/OTP Versions
 


### PR DESCRIPTION
## Proposed Changes

This plugin still uses a pair of Mnesia tables. If not running, Mnesia is started in a single-node cluster mode. This is enough, as the used tables are not replicated.

(As discussed in https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/pull/291)

CT tests to be added.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
